### PR TITLE
accept alternates for credential field pairs

### DIFF
--- a/launcher/clis.go
+++ b/launcher/clis.go
@@ -24,21 +24,21 @@ func startShell(name string, args []string) error {
 func LaunchMySQL(localPort int, creds models.Credentials) error {
 	fmt.Printf("%+v\n", creds)
 	return startShell("mysql", []string{
-		"-u", creds.Username,
+		"-u", creds.GetUsername(),
 		"-h", "0",
-		"-p" + creds.Password,
-		"-D", creds.DBName,
+		"-p" + creds.GetPassword(),
+		"-D", creds.GetDBName(),
 		"-P", strconv.Itoa(localPort),
 	})
 }
 
 func LaunchPSQL(localPort int, creds models.Credentials) error {
-	os.Setenv("PGPASSWORD", creds.Password)
+	os.Setenv("PGPASSWORD", creds.GetPassword())
 	return startShell("psql", []string{
 		"-h", "localhost",
 		"-p", fmt.Sprintf("%d", localPort),
-		creds.DBName,
-		creds.Username,
+		creds.GetDBName(),
+		creds.GetUsername(),
 	})
 }
 

--- a/launcher/ssh_tunnel.go
+++ b/launcher/ssh_tunnel.go
@@ -55,7 +55,7 @@ func (t *SSHTunnel) Close() error {
 func NewSSHTunnel(creds models.Credentials, appName string) SSHTunnel {
 	localPort := getAvailablePort()
 
-	cmd := exec.Command("cf", "ssh", "-N", "-L", fmt.Sprintf("%d:%s:%s", localPort, creds.Host, creds.Port), appName)
+	cmd := exec.Command("cf", "ssh", "-N", "-L", fmt.Sprintf("%d:%s:%s", localPort, creds.GetHost(), creds.GetPort()), appName)
 	// should only print in the case of an issue
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/models/credentials.go
+++ b/models/credentials.go
@@ -2,18 +2,26 @@ package models
 
 import "encoding/json"
 
-type ServiceKeyResponse struct {
-	Resources []ServiceKeyResource `json:"resources"`
+type serviceKeyResponse struct {
+	Resources []serviceKeyResource `json:"resources"`
 }
 
-type ServiceKeyResource struct {
+type serviceKeyResource struct {
 	Entity struct {
-		Credentials CredentialsJSON `json:"credentials"`
+		Credentials credentialsJSON `json:"credentials"`
 	} `json:"entity"`
 }
 
+type Credentials interface {
+	GetDBName() string
+	GetHost() string
+	GetUsername() string
+	GetPassword() string
+	GetPort() string
+}
+
 // http://stackoverflow.com/a/28035946/358804
-type CredentialsJSON struct {
+type credentialsJSON struct {
 	// these groups of fields should be interchangeable
 	DBName string `json:"db_name"`
 	Name   string `json:"name"`
@@ -27,43 +35,39 @@ type CredentialsJSON struct {
 	Port     string `json:"port"`
 }
 
-func (c *CredentialsJSON) GetDBName() string {
+func (c credentialsJSON) GetDBName() string {
 	if c.Name != "" {
 		return c.Name
 	}
 	return c.DBName
 }
 
-func (c *CredentialsJSON) GetHost() string {
+func (c credentialsJSON) GetHost() string {
 	if c.Host != "" {
 		return c.Host
 	}
 	return c.Hostname
 }
 
-type Credentials struct {
-	DBName   string
-	Host     string
-	Username string
-	Password string
-	Port     string
+func (c credentialsJSON) GetUsername() string {
+	return c.Username
+}
+
+func (c credentialsJSON) GetPassword() string {
+	return c.GetPassword()
+}
+
+func (c credentialsJSON) GetPort() string {
+	return c.Port
 }
 
 func CredentialsFromJSON(body string) (creds Credentials, err error) {
-	serviceKeyResponse := ServiceKeyResponse{}
+	serviceKeyResponse := serviceKeyResponse{}
 	err = json.Unmarshal([]byte(body), &serviceKeyResponse)
 	if err != nil {
 		return
 	}
-	jsonCreds := serviceKeyResponse.Resources[0].Entity.Credentials
-
-	creds = Credentials{
-		DBName:   jsonCreds.GetDBName(),
-		Host:     jsonCreds.GetHost(),
-		Username: jsonCreds.Username,
-		Password: jsonCreds.Password,
-		Port:     jsonCreds.Port,
-	}
+	creds = serviceKeyResponse.Resources[0].Entity.Credentials
 
 	return
 }

--- a/models/credentials.go
+++ b/models/credentials.go
@@ -8,17 +8,45 @@ type ServiceKeyResponse struct {
 
 type ServiceKeyResource struct {
 	Entity struct {
-		Credentials Credentials `json:"credentials"`
+		Credentials CredentialsJSON `json:"credentials"`
 	} `json:"entity"`
 }
 
-type Credentials struct {
-	DBName   string `json:"db_name"`
-	Name     string `json:"name"`
+// http://stackoverflow.com/a/28035946/358804
+type CredentialsJSON struct {
+	// these groups of fields should be interchangeable
+	DBName string `json:"db_name"`
+	Name   string `json:"name"`
+
 	Host     string `json:"host"`
+	Hostname string `json:"hostname"`
+	///////////////////////////////////////////////////
+
 	Username string `json:"username"`
 	Password string `json:"password"`
 	Port     string `json:"port"`
+}
+
+func (c *CredentialsJSON) GetDBName() string {
+	if c.Name != "" {
+		return c.Name
+	}
+	return c.DBName
+}
+
+func (c *CredentialsJSON) GetHost() string {
+	if c.Host != "" {
+		return c.Host
+	}
+	return c.Hostname
+}
+
+type Credentials struct {
+	DBName   string
+	Host     string
+	Username string
+	Password string
+	Port     string
 }
 
 func CredentialsFromJSON(body string) (creds Credentials, err error) {
@@ -27,6 +55,15 @@ func CredentialsFromJSON(body string) (creds Credentials, err error) {
 	if err != nil {
 		return
 	}
-	creds = serviceKeyResponse.Resources[0].Entity.Credentials
+	jsonCreds := serviceKeyResponse.Resources[0].Entity.Credentials
+
+	creds = Credentials{
+		DBName:   jsonCreds.GetDBName(),
+		Host:     jsonCreds.GetHost(),
+		Username: jsonCreds.Username,
+		Password: jsonCreds.Password,
+		Port:     jsonCreds.Port,
+	}
+
 	return
 }

--- a/models/credentials_test.go
+++ b/models/credentials_test.go
@@ -1,0 +1,63 @@
+package models
+
+import (
+	"fmt"
+	"testing"
+)
+
+const JSONWrap = `{
+	"resources": [
+		{
+			"entity": {
+				"credentials": %s
+			}
+		}
+	]
+}`
+
+type credentialsFromJSONTest struct {
+	entityJSON     string
+	expectedDBName string
+	expectedHost   string
+}
+
+func TestCredentialsFromJSON(t *testing.T) {
+	tests := []credentialsFromJSONTest{
+		{
+			`{
+				"db_name": "name",
+				"host": "host.com",
+				"password": "pass",
+				"port": "5432",
+				"username": "user"
+			}`,
+			"name",
+			"host.com",
+		},
+		{
+			`{
+				"name": "name",
+				"hostname": "host.com",
+				"password": "pass",
+				"port": "5432",
+				"username": "user"
+			}`,
+			"name",
+			"host.com",
+		},
+	}
+
+	for _, test := range tests {
+		fullJSON := fmt.Sprintf(JSONWrap, test.entityJSON)
+		creds, err := CredentialsFromJSON(fullJSON)
+		if err != nil {
+			t.Error(err)
+		}
+		if creds.Host != test.expectedHost {
+			t.Errorf("Expected: %v. Actual: %v.", test.expectedHost, creds.Host)
+		}
+		if creds.DBName != test.expectedDBName {
+			t.Errorf("Expected: %v. Actual: %v.", test.expectedDBName, creds.DBName)
+		}
+	}
+}

--- a/models/credentials_test.go
+++ b/models/credentials_test.go
@@ -53,11 +53,11 @@ func TestCredentialsFromJSON(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if creds.Host != test.expectedHost {
-			t.Errorf("Expected: %v. Actual: %v.", test.expectedHost, creds.Host)
+		if creds.GetHost() != test.expectedHost {
+			t.Errorf("Expected: %v. Actual: %v.", test.expectedHost, creds.GetHost())
 		}
-		if creds.DBName != test.expectedDBName {
-			t.Errorf("Expected: %v. Actual: %v.", test.expectedDBName, creds.DBName)
+		if creds.GetDBName() != test.expectedDBName {
+			t.Errorf("Expected: %v. Actual: %v.", test.expectedDBName, creds.GetDBName())
 		}
 	}
 }


### PR DESCRIPTION
Builds on #1 (meaning that should be merged first, then the target of this PR should be changed to `master`).

This pull request establishes a pattern for handling credentials from various brokers that use different property names for the same thing. For example, we can assume `host` and `hostname` are synonymous.