### PR TITLE
add option for connecting the local client manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Setting up SSH tunnel...
 mysql>
 ```
 
+### Manual client connection
+
+If you're using a non-default client (such as a GUI), run with the `-no-client` option to set up your client connection on your own.
+
 ## Development
 
 ```sh

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -9,10 +9,15 @@ import (
 	"code.cloudfoundry.org/cli/plugin"
 )
 
-func Connect(cliConnection plugin.CliConnection, appName, serviceInstanceName string) (err error) {
+type Options struct {
+	AppName             string
+	ServiceInstanceName string
+}
+
+func Connect(cliConnection plugin.CliConnection, options Options) (err error) {
 	fmt.Println("Finding the service instance details...")
 
-	serviceInstance, err := models.FetchServiceInstance(cliConnection, serviceInstanceName)
+	serviceInstance, err := models.FetchServiceInstance(cliConnection, options.ServiceInstanceName)
 	if err != nil {
 		return
 	}
@@ -34,7 +39,7 @@ func Connect(cliConnection plugin.CliConnection, appName, serviceInstanceName st
 	}
 
 	fmt.Println("Setting up SSH tunnel...")
-	tunnel := launcher.NewSSHTunnel(creds, appName)
+	tunnel := launcher.NewSSHTunnel(creds, options.AppName)
 	err = tunnel.Open()
 	if err != nil {
 		return

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -17,8 +17,7 @@ type Options struct {
 	ConnectClient       bool
 }
 
-func manualConnect(tunnel launcher.SSHTunnel, creds models.Credentials) (err error) {
-	rawTemplate := `Skipping call to client CLI. Connection information:
+const manualConnectInstructions = `Skipping call to client CLI. Connection information:
 
 Host: localhost
 Port: {{.Port}}
@@ -29,20 +28,22 @@ Name: {{.Name}}
 Leave this terminal open while you want to use the SSH tunnel. Press Control-C to stop.
 `
 
-	// http://julianyap.com/2013/09/23/using-anonymous-structs-to-pass-data-to-templates-in-golang.html
-	connectionData := struct {
-		Port int
-		User string
-		Pass string
-		Name string
-	}{
-		tunnel.LocalPort,
-		creds.GetUsername(),
-		creds.GetPassword(),
-		creds.GetDBName(),
+type localConnectionData struct {
+	Port int
+	User string
+	Pass string
+	Name string
+}
+
+func manualConnect(tunnel launcher.SSHTunnel, creds models.Credentials) (err error) {
+	connectionData := localConnectionData{
+		Port: tunnel.LocalPort,
+		User: creds.GetUsername(),
+		Pass: creds.GetPassword(),
+		Name: creds.GetDBName(),
 	}
 
-	tmpl, err := template.New("").Parse(rawTemplate)
+	tmpl, err := template.New("").Parse(manualConnectInstructions)
 	if err != nil {
 		return
 	}

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -11,6 +11,7 @@ import (
 	"code.cloudfoundry.org/cli/plugin"
 )
 
+// Options are the structured representation of the command-line flags/arguments.
 type Options struct {
 	AppName             string
 	ServiceInstanceName string
@@ -58,6 +59,7 @@ func manualConnect(tunnel launcher.SSHTunnel, creds models.Credentials) (err err
 	return
 }
 
+// Connect performs the primary action of the plugin: providing an SSH tunnel and launching the appropriate client, if desired.
 func Connect(cliConnection plugin.CliConnection, options Options) (err error) {
 	fmt.Println("Finding the service instance details...")
 
@@ -93,10 +95,8 @@ func Connect(cliConnection plugin.CliConnection, options Options) (err error) {
 	if options.ConnectClient {
 		err = launcher.LaunchDBCLI(serviceInstance, tunnel, creds)
 		return
-	} else {
-		err = manualConnect(tunnel, creds)
-		return
 	}
 
+	err = manualConnect(tunnel, creds)
 	return
 }

--- a/launcher/ssh_tunnel.go
+++ b/launcher/ssh_tunnel.go
@@ -15,12 +15,14 @@ func getAvailablePort() int {
 	return freeport.GetPort()
 }
 
+// SSHTunnel represents an underlying SSH tunnel process. The struct should be created via NewSSHTunnel().
 type SSHTunnel struct {
 	LocalPort int
 	cmd       *exec.Cmd
 	errChan   chan error
 }
 
+// Open starts the underlying SSH tunnel process.
 func (t *SSHTunnel) Open() (err error) {
 	// Start the (long-running) SSH tunnel command, and ensure that it doesn't fail. Because of how Process management in Go works, this needs to happen asynchronously.
 	// https://groups.google.com/d/msg/golang-nuts/XviHC3bJF8s/PUOYzcsmvwMJ
@@ -47,14 +49,17 @@ func (t *SSHTunnel) Open() (err error) {
 	return
 }
 
+// Wait will block until the SSH tunnel is closed, either intentionally or not.
 func (t *SSHTunnel) Wait() error {
 	return <-t.errChan
 }
 
+// Close will terminate the underlying SSH tunnel process.
 func (t *SSHTunnel) Close() error {
 	return t.cmd.Process.Kill()
 }
 
+// NewSSHTunnel prepares the underlying Cloud Foundry CLI process for creating an SSH tunnel to a service instance.
 func NewSSHTunnel(creds models.Credentials, appName string) SSHTunnel {
 	localPort := getAvailablePort()
 

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ func (c *DBConnectPlugin) parseOptions(args []string) (options connector.Options
 	metadata := c.GetMetadata()
 	command := metadata.Commands[0]
 	flags := flag.NewFlagSet(command.Name, flag.ExitOnError)
+	option := "no-client"
+	noClient := flags.Bool(option, false, command.UsageDetails.Options[option])
 
 	err = flags.Parse(args[1:])
 	if err != nil {
@@ -35,6 +37,7 @@ func (c *DBConnectPlugin) parseOptions(args []string) (options connector.Options
 	options = connector.Options{
 		AppName:             nonFlagArgs[0],
 		ServiceInstanceName: nonFlagArgs[1],
+		ConnectClient:       !(*noClient),
 	}
 	return
 }
@@ -79,7 +82,10 @@ func (c *DBConnectPlugin) GetMetadata() plugin.PluginMetadata {
 				Name:     SUBCOMMAND,
 				HelpText: "Open a shell that's connected to a database service instance",
 				UsageDetails: plugin.Usage{
-					Usage: "\n   cf " + SUBCOMMAND + " <app_name> <service_instance_name>",
+					Usage: "\n   cf " + SUBCOMMAND + " [-no-client] <app_name> <service_instance_name>",
+					Options: map[string]string{
+						"no-client": "If this param is passed, the CLI client for the service won't be started, and the connection information will be printed to the console. Useful for connecting to the service through a GUI.",
+					},
 				},
 			},
 		},

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/18F/cf-db-connect/connector"
+	"github.com/stretchr/testify/assert"
+)
+
+type parseOptionsTest struct {
+	args            string
+	expectError     bool
+	expectedOptions connector.Options
+}
+
+func TestParseOptions(t *testing.T) {
+	tests := []parseOptionsTest{
+		{
+			"connect-to-db app service",
+			false,
+			connector.Options{
+				"app",
+				"service",
+				true,
+			},
+		},
+		{
+			"connect-to-db -no-client app service",
+			false,
+			connector.Options{
+				"app",
+				"service",
+				false,
+			},
+		},
+		{
+			"connect-to-db foo bar baz",
+			true,
+			connector.Options{},
+		},
+	}
+
+	plugin := DBConnectPlugin{}
+	for _, test := range tests {
+		args := strings.Split(test.args, " ")
+		opts, err := plugin.parseOptions(args)
+		if test.expectError {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+			assert.Equal(t, opts, test.expectedOptions)
+		}
+	}
+}


### PR DESCRIPTION
Closes #17. Example:

```
$ cf connect-to-db -no-client todo-app mysql-service
Finding the service instance details...
Setting up SSH tunnel...
Skipping call to client CLI. Connection information:

Host: localhost
Port: 49158
Username: ...
Password: ...
Name: ...

Leave this terminal open while you want to use the SSH tunnel. Press Control-C to stop.
```

/cc @yozlet

