### PR TITLE
fall back to -no-client behavior if client can't be identified

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -60,6 +60,25 @@ func manualConnect(tunnel launcher.SSHTunnel, creds models.Credentials) (err err
 	return
 }
 
+func handleClient(
+	options Options,
+	tunnel launcher.SSHTunnel,
+	si models.ServiceInstance,
+	creds models.Credentials,
+) error {
+	if options.ConnectClient {
+		srv, found := service.GetService(si)
+		if found {
+			fmt.Println("Connecting client...")
+			return srv.Launch(tunnel.LocalPort, creds)
+		}
+
+		fmt.Printf("Unable to find matching client for service '%s' with plan '%s'. Falling back to `-no-client` behavior.\n", si.Service, si.Plan)
+	}
+
+	return manualConnect(tunnel, creds)
+}
+
 // Connect performs the primary action of the plugin: providing an SSH tunnel and launching the appropriate client, if desired.
 func Connect(cliConnection plugin.CliConnection, options Options) (err error) {
 	fmt.Println("Finding the service instance details...")
@@ -93,17 +112,6 @@ func Connect(cliConnection plugin.CliConnection, options Options) (err error) {
 	}
 	defer tunnel.Close()
 
-	if options.ConnectClient {
-		srv, found := service.GetService(serviceInstance)
-		if found {
-			fmt.Println("Connecting client...")
-			err = srv.Launch(tunnel.LocalPort, creds)
-			return
-		}
-
-		fmt.Printf("Unable to find matching client for service '%s' with plan '%s'. Falling back to `-no-client` behavior.\n", serviceInstance.Service, serviceInstance.Plan)
-	}
-
-	err = manualConnect(tunnel, creds)
+	err = handleClient(options, tunnel, serviceInstance, creds)
 	return
 }

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -1,7 +1,6 @@
 package connector
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"text/template"
@@ -98,13 +97,11 @@ func Connect(cliConnection plugin.CliConnection, options Options) (err error) {
 		srv, found := service.GetService(serviceInstance)
 		if found {
 			fmt.Println("Connecting client...")
-			srv.Launch(tunnel.LocalPort, creds)
-		} else {
-			msg := fmt.Sprintf("Unsupported service. Service Name '%s' Plan Name '%s'. File an issue at https://github.com/18F/cf-db-connect/issues/new", serviceInstance.Service, serviceInstance.Plan)
-			return errors.New(msg)
+			err = srv.Launch(tunnel.LocalPort, creds)
+			return
 		}
 
-		return
+		fmt.Printf("Unable to find matching client for service '%s' with plan '%s'. Falling back to `-no-client` behavior.\n", serviceInstance.Service, serviceInstance.Plan)
 	}
 
 	err = manualConnect(tunnel, creds)


### PR DESCRIPTION
Closes part of https://github.com/18F/cf-db-connect/issues/19.

Builds on #24. Merge that one first, then change the base of this to `master`.

This pull request makes the plugin fail gracefully when it isn't able to identify the underlying service. Instead, the plugin will now prompt the user to connect their client manually. Example:

```
$ cf connect-to-db todo-app some-service
Finding the service instance details...
Setting up SSH tunnel...
Unable to find matching client for service 'some-broker' with plan 'shared-something'. Falling back to `-no-client` behavior.
Skipping call to client CLI. Connection information:

Host: localhost
Port: 59126
Username: ...
Password: ...
Name: ...

Leave this terminal open while you want to use the SSH tunnel. Press Control-C to stop.
```

I couldn't figure out a good way to structure this to code to be testable — would love ideas.